### PR TITLE
Add uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,8 @@ install: all
 	cp $(NAME).1 $(DESTDIR)$(MANPREFIX)/man1/
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
 
-.PHONY: all clean install
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/bin/$(NAME)
+	rm -f $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
+
+.PHONY: all clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ install: all
 clean:
 	rm -f -- $(NAME) $(OBJ)
 
-.PHONY: clean
+.PHONY: all clean install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 .SUFFIXES:
 PREFIX ?= /usr/local
-MAN     = $(PREFIX)/share/man
+MANPREFIX = $(PREFIX)/share/man
 NAME    = stw
 CC      = cc
 INCS    = -I/usr/include/X11 -I/usr/include/freetype2
@@ -25,8 +25,8 @@ install: all
 	mkdir -p $(PREFIX)/bin
 	cp -f $(NAME) $(PREFIX)/bin
 	chmod 755 ${DESTDIR}${PREFIX}/bin/$(NAME)
-	mkdir -p ${DESTDIR}${MAN}/man1
-	cp stw.1 ${DESTDIR}${MAN}/man1/stw.1
+	mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	cp stw.1 ${DESTDIR}${MANPREFIX}/man1/stw.1
 
 clean:
 	rm -f -- $(NAME) $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ install: all
 	cp -f $(NAME) $(DESTDIR)$(PREFIX)/bin
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/$(NAME)
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
-	cp $(NAME).1 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
+	cp $(NAME).1 $(DESTDIR)$(MANPREFIX)/man1/
+	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
 
 clean:
 	rm -f -- $(NAME) $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install: all
 	cp -f $(NAME) $(PREFIX)/bin
 	chmod 755 ${DESTDIR}${PREFIX}/bin/$(NAME)
 	mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	cp stw.1 ${DESTDIR}${MANPREFIX}/man1/stw.1
+	cp $(NAME).1 ${DESTDIR}${MANPREFIX}/man1/$(NAME).1
 
 clean:
 	rm -f -- $(NAME) $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ $(OBJ):
 .c.o:
 	$(CC) $(CFLAGS) -c $<
 
+clean:
+	rm -f -- $(NAME) $(OBJ)
+
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp -f $(NAME) $(DESTDIR)$(PREFIX)/bin
@@ -28,8 +31,5 @@ install: all
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	cp $(NAME).1 $(DESTDIR)$(MANPREFIX)/man1/
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
-
-clean:
-	rm -f -- $(NAME) $(OBJ)
 
 .PHONY: all clean install

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBS    = -lX11 -lfontconfig -lXft -lXrender
 CFLAGS  = -std=c99 -pedantic -Wall -Werror -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2 $(INCS)
 LDFLAGS = $(LIBS)
 SRC     = $(NAME).c
-OBJ     = ${SRC:.c=.o}
+OBJ     = $(SRC:.c=.o)
 
 all: $(NAME)
 
@@ -24,9 +24,9 @@ $(OBJ):
 install: all
 	mkdir -p $(PREFIX)/bin
 	cp -f $(NAME) $(PREFIX)/bin
-	chmod 755 ${DESTDIR}${PREFIX}/bin/$(NAME)
-	mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	cp $(NAME).1 ${DESTDIR}${MANPREFIX}/man1/$(NAME).1
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/$(NAME)
+	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
+	cp $(NAME).1 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
 
 clean:
 	rm -f -- $(NAME) $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ $(OBJ):
 	$(CC) $(CFLAGS) -c $<
 
 install: all
-	mkdir -p $(PREFIX)/bin
-	cp -f $(NAME) $(PREFIX)/bin
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	cp -f $(NAME) $(DESTDIR)$(PREFIX)/bin
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/$(NAME)
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	cp $(NAME).1 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1


### PR DESCRIPTION
The intent of this pull request is to add a target named "uninstall" which does the opposite of "install".

There are several other style changes to the Makefile
* Move `clean` target above `install` target
* Be consistent with syntax for variable references (i.e. parentheses and braces)
* Use `$(NAME)` where possible
* Add targets to `.PHONY`
* To be similar to other suckless Makefiles
  * Do `chmod 644` on result man file during install
  * Rename `MAN` to `MANPREFIX`
  * Restore missing `$(DESTDIR)` in `install` recipe
