### PR TITLE
fix 'undefined reference' for many X11 symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OBJ     = $(SRC:.c=.o)
 all: $(NAME)
 
 $(NAME): $(OBJ)
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) $^ $(LDFLAGS) -o $@
 
 .SUFFIXES: .c .o
 $(OBJ):


### PR DESCRIPTION
I checked with '-v' option that path where my libX11.so exists is correct, try to pass '-L/usr/lib/x86_64-linux-gnu' without luck. After reading some links I found this solution.
Links:
https://stackoverflow.com/questions/57715866/have-x11-c-program-compiled-getting-undefined-reference-errors-what-libs-are
https://www.linuxquestions.org/questions/ubuntu-63/compiling-and-linking-in-g-4175599946/