### PR TITLE
Suppress -Wextra warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ all: stw
 stw: stw.o
 	$(CC) $^ $(STWLDFLAGS) -o $@
 
+stw.o: arg.h config.h config.mk
+
 clean:
 	rm -f stw stw.o
 

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 # See LICENSE file for copyright and license details. 
 
 # paths
-PREFIX    = /usr/local
+PREFIX ?= /usr/local
 MANPREFIX = $(PREFIX)/share/man
 
 # includes and libs
@@ -10,5 +10,5 @@ LIBS = -lX11 -lXft -lXrender `pkg-config --libs fontconfig`
 
 # flags
 STWCPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2
-STWCFLAGS   = -std=c99 -pedantic -Wall -Werror $(INCS) $(STWCPPFLAGS) $(CPPFLAGS) $(CFLAGS)
+STWCFLAGS   = -std=c99 -pedantic -Wall -Wno-shadow -Wno-switch-default $(INCS) $(STWCPPFLAGS) $(CPPFLAGS) $(CFLAGS)
 STWLDFLAGS  = $(LIBS) $(LDFLAGS)

--- a/stw.c
+++ b/stw.c
@@ -114,8 +114,6 @@ start_cmd()
 		setpgid(0, 0);
 		execvp(cmd[0], cmd);
 		exit(1);
-	default:
-		break;
 	}
 
 	close(fds[1]);
@@ -177,7 +175,7 @@ draw()
 	for (char *line = text; line < text + len; line += strlen(line) + 1) {
 		XGlyphInfo ex;
 		XftTextExtentsUtf8(dpy, xfont, (unsigned char *)line, strlen(line), &ex);
-		if (ex.xOff > (short int)window_width)
+		if (ex.xOff > window_width)
 			window_width = ex.xOff;
 		window_height += xfont->ascent + xfont->descent;
 	}

--- a/stw.c
+++ b/stw.c
@@ -51,6 +51,7 @@ static unsigned int screen_width, screen_height;
 static unsigned int window_width, window_height;
 static bool hidden = true;
 
+__attribute__ ((noreturn))
 static void
 die(const char *fmt, ...)
 {
@@ -113,6 +114,8 @@ start_cmd()
 		setpgid(0, 0);
 		execvp(cmd[0], cmd);
 		exit(1);
+	default:
+		break;
 	}
 
 	close(fds[1]);
@@ -174,7 +177,7 @@ draw()
 	for (char *line = text; line < text + len; line += strlen(line) + 1) {
 		XGlyphInfo ex;
 		XftTextExtentsUtf8(dpy, xfont, (unsigned char *)line, strlen(line), &ex);
-		if (ex.xOff > window_width)
+		if (ex.xOff > (short int)window_width)
 			window_width = ex.xOff;
 		window_height += xfont->ascent + xfont->descent;
 	}


### PR DESCRIPTION
In my `CPPFLAGS` I use `-Wextra`.  Since `-Werror` is specified in STWCFLAGS, there are some errors when I compile.