### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/stw.c
+++ b/stw.c
@@ -24,7 +24,7 @@ struct g {
 
 #include "config.h"
 
-#define LENGTH(X) (sizeof X / sizeof X[0])
+#define LENGTH(X) (sizeof(X) / sizeof((X)[0]))
 #define INITIAL_CAPACITY 2
 
 static char *argv0;
@@ -58,15 +58,15 @@ die(const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	vfprintf(stderr, fmt, ap);
+	(void)vfprintf(stderr, fmt, ap);
 	va_end(ap);
 
 	if (fmt[0] && fmt[strlen(fmt)-1] == ':') {
-		fputc(' ', stderr);
+		(void)fputc(' ', stderr);
 		errno = tmp;
 		perror(NULL);
 	} else {
-		fputc('\n', stderr);
+		(void)fputc('\n', stderr);
 	}
 
 	exit(1);
@@ -113,6 +113,8 @@ start_cmd()
 		setpgid(0, 0);
 		execvp(cmd[0], cmd);
 		exit(1);
+	default:
+		break;
 	}
 
 	close(fds[1]);
@@ -324,7 +326,7 @@ run()
 				if (ev.type == Expose && ev.xexpose.count == 0) {
 					// Last expose event processed, redraw once
 					dirty = true;
-				
+
 				} else if (ev.type == ButtonPress) {
 					// X Window was clicked, restart subcommand
 					if (cmdpid && kill(-cmdpid, SIGTERM) == -1) {
@@ -346,7 +348,7 @@ run()
 			} else {
 				XLowerWindow(dpy, win);
 			}
-			
+
 			XMapWindow(dpy, win);
 
 			int x = pos(px, screen_width);


### PR DESCRIPTION
These changes fix the following warnings issued by clang-tidy.

```
 stw.c:27:27: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
 #define LENGTH(X) (sizeof X / sizeof X[0])
                           ^
                           ()
 stw.c:27:38: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
 #define LENGTH(X) (sizeof X / sizeof X[0])
                                      ^
                                      ()
 stw.c:61:2: warning: the value returned by this function should be used [cert-err33-c]
         vfprintf(stderr, fmt, ap);
         ^~~~~~~~~~~~~~~~~~~~~~~~~
 stw.c:61:2: note: cast the expression to void to silence this warning
 stw.c:65:3: warning: the value returned by this function should be used [cert-err33-c]
                 fputc(' ', stderr);
                 ^~~~~~~~~~~~~~~~~~
 stw.c:65:3: note: cast the expression to void to silence this warning
 stw.c:69:3: warning: the value returned by this function should be used [cert-err33-c]
                 fputc('\n', stderr);
                 ^~~~~~~~~~~~~~~~~~~
 stw.c:69:3: note: cast the expression to void to silence this warning
 stw.c:104:2: warning: potential uncovered code path; add a default label [hicpp-multiway-paths-covered]
         switch (cmdpid) {
         ^
```