### PR TITLE
Add clickthrough support

### DIFF
--- a/config.h
+++ b/config.h
@@ -28,4 +28,4 @@ signals stw to render buffered text and continue with next frame;
 it is the only valid use of non-printable characters in subcommand output */
 static char delimeter[] = "\4";
 
-static bool window_on_top = 1;
+static bool window_on_top = 0;

--- a/config.h
+++ b/config.h
@@ -28,4 +28,4 @@ signals stw to render buffered text and continue with next frame;
 it is the only valid use of non-printable characters in subcommand output */
 static char delimeter[] = "\4";
 
-static bool window_on_top = 0;
+static bool window_on_top = 1;

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,7 @@ MANPREFIX = $(PREFIX)/share/man
 
 # includes and libs
 INCS = `pkg-config --cflags fontconfig`
-LIBS = `pkg-config --libs fontconfig xft xrender`
+LIBS = `pkg-config --libs fontconfig xft xrender xfixes`
 
 # flags
 STWCPPFLAGS = -DVERSION=\"$(VERSION)\" -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2 $(INCS)

--- a/stw.c
+++ b/stw.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <X11/Xft/Xft.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/shape.h>
 #include <X11/extensions/Xfixes.h>
 
 #include "arg.h"
@@ -451,7 +452,7 @@ setup(char *font)
 	if(overlay) {
 		XRectangle rect;
 		XserverRegion region = XFixesCreateRegion(dpy, &rect, 1);
-		XFixesSetWindowShapeRegion(dpy, win, 2, 0, 0, region);
+		XFixesSetWindowShapeRegion(dpy, win, ShapeInput, 0, 0, region);
 		XFixesDestroyRegion(dpy, region);
 	}
 

--- a/stw.c
+++ b/stw.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <X11/Xft/Xft.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/Xfixes.h>
 
 #include "arg.h"
 
@@ -50,6 +51,7 @@ static XftFont *xfont;
 static unsigned int screen_width, screen_height;
 static unsigned int window_width, window_height;
 static bool hidden = true;
+static bool overlay = false;
 
 __attribute__ ((noreturn))
 static void
@@ -445,6 +447,14 @@ setup(char *font)
 		&swa
 	);
 
+	// create a fixed region to allow passthrough
+	if(overlay) {
+		XRectangle rect;
+		XserverRegion region = XFixesCreateRegion(dpy, &rect, 1);
+		XFixesSetWindowShapeRegion(dpy, win, 2, 0, 0, region);
+		XFixesDestroyRegion(dpy, region);
+	}
+
 	XGCValues gcvalues = {0};
 	gcvalues.graphics_exposures = False;
 	xgc = XCreateGC(dpy, drawable, GCGraphicsExposures, &gcvalues);
@@ -568,6 +578,9 @@ main(int argc, char *argv[])
 	case 't':
 		window_on_top = true;
 		break;
+    case 'o':
+        overlay = true;
+        break;
 	default:
 		usage();
 	} ARGEND


### PR DESCRIPTION
Add clickthrough support through

`XFixesSetWindowShapeRegion(dpy, win, ShapeInput, 0, 0, region);`

and the input flag `-o`

Since the command ignores any input to the window the refresh on ButtonPress is effectively disabled.
